### PR TITLE
Implement a script to create a corpus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ Cargo.lock
 
 hfuzz_target
 hfuzz_workspace
+
+noir_fuzzers/corpus

--- a/noir_fuzzers/create_corpus.sh
+++ b/noir_fuzzers/create_corpus.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -e
+
+repos=(
+    "noir-lang/noir"
+)
+mkdir -p corpus
+for repo in "${repos[@]}"; do
+  base=$(basename "${repo}")
+  echo $base
+  if ! [[ -d "${base}" ]]; then
+    git clone --jobs 4 --depth 1 "https://github.com/${repo}"
+  fi
+  for f in $(find "${base}" -type f -name "*.nr"); do
+    echo "${f}"
+    cp "${f}" corpus/"${base}-$(sha256sum "${f}" | head -c 5)-$(basename "${f}")"
+  done
+done
+
+rm -rf noir 


### PR DESCRIPTION
This PR adds a script that can retrieve all `.nr` files from the Noir repo and compile them in a `/corpus` folder. 